### PR TITLE
feat: worldwide flow — user-centered map zoom, cardinal directions, LocalReferenceService, service hardening, cleaner Home

### DIFF
--- a/src/app/features/home/home/home.component.html
+++ b/src/app/features/home/home/home.component.html
@@ -76,13 +76,7 @@
           <span class="disappear-point">🔴 {{ pass.to }}</span>
         </div>
 
-        <!-- NUEVO: Mostrar dirección cardinal -->
-        @if (pass.direction) {
-        <div class="pass-direction">
-          <span class="compass">{{ pass.compass }}</span>
-          <span class="direction-text">{{ pass.direction }}</span>
-        </div>
-        }
+        <div class="pass-elevation-human">🏔️ {{ pass.altitude }}</div>
 
         <div class="pass-duration-simple">{{ pass.duration }} minutes visible</div>
         <div class="brightness-simple">{{ pass.brightness }}</div>

--- a/src/app/features/home/home/home.component.scss
+++ b/src/app/features/home/home/home.component.scss
@@ -484,3 +484,28 @@
 .view-details-btn:hover {
   background: #52d8b3;
 }
+
+.brightness-simple {
+  font-size: 0.9rem;           // Más grande para las estrellas
+  color: #ffd700;
+  letter-spacing: 0.05em;      // Espaciado entre estrellas
+  line-height: 1.2;
+  font-weight: 500;            // Más grueso para mejor visibilidad
+}
+
+.pass-description-simple {
+  // ... existing styles ...
+  
+  // ✅ NUEVO: Estilo para elevación humana
+  .pass-elevation-human {
+    font-size: 0.8rem;
+    color: #4fc3f7;           // Azul claro para destacar
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+    
+    // Icono de montaña más visible
+    &::first-letter {
+      font-size: 1em;
+    }
+  }
+}

--- a/src/app/services/local-reference.service.ts
+++ b/src/app/services/local-reference.service.ts
@@ -1,0 +1,144 @@
+// src/app/services/local-reference.service.ts
+// PASO 1: Crear este archivo NUEVO
+
+import { Injectable } from '@angular/core';
+
+export interface LocalReference {
+    startCoords: [number, number];  // Punto donde aparece ISS
+    endCoords: [number, number];    // Punto donde desaparece ISS
+    from: string;                   // "Northwest"
+    to: string;                     // "Southeast"
+    elevationDescription: string;   // "High in the sky - look up 45°"
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class LocalReferenceService {
+
+    /**
+     * 🎯 MÉTODO PRINCIPAL: Generar referencias locales para cualquier ciudad
+     */
+    generateLocalReferences(
+        userLat: number,
+        userLon: number,
+        startAzimuth: number,
+        endAzimuth: number,
+        maxElevation: number
+    ): LocalReference {
+
+        const distance = 1.5; // 1.5km - perfecto para contexto móvil
+
+        // Calcular puntos matemáticamente
+        const startPoint = this.getPointFromBearing(userLat, userLon, startAzimuth, distance);
+        const endPoint = this.getPointFromBearing(userLat, userLon, endAzimuth, distance);
+
+        // Convertir azimuth a direcciones cardinales
+        const fromDirection = this.azimuthToCardinal(startAzimuth);
+        const toDirection = this.azimuthToCardinal(endAzimuth);
+
+        // Generar descripción humana de elevación
+        const elevationDescription = this.getElevationDescription(maxElevation);
+
+        return {
+            startCoords: [startPoint.lon, startPoint.lat],
+            endCoords: [endPoint.lon, endPoint.lat],
+            from: fromDirection,
+            to: toDirection,
+            elevationDescription
+        };
+    }
+
+    /**
+     * 🧮 MATEMÁTICAS: Calcular punto a X km en dirección Y
+     */
+    private getPointFromBearing(
+        lat: number,
+        lon: number,
+        bearing: number,
+        distance: number
+    ): { lat: number; lon: number } {
+
+        const R = 6371; // Radio de la Tierra en km
+        const d = distance / R; // Distancia angular
+
+        // Convertir a radianes
+        const lat1 = lat * Math.PI / 180;
+        const lon1 = lon * Math.PI / 180;
+        const bearingRad = bearing * Math.PI / 180;
+
+        // Calcular nueva latitud
+        const lat2 = Math.asin(
+            Math.sin(lat1) * Math.cos(d) +
+            Math.cos(lat1) * Math.sin(d) * Math.cos(bearingRad)
+        );
+
+        // Calcular nueva longitud
+        const lon2 = lon1 + Math.atan2(
+            Math.sin(bearingRad) * Math.sin(d) * Math.cos(lat1),
+            Math.cos(d) - Math.sin(lat1) * Math.sin(lat2)
+        );
+
+        // Convertir de vuelta a grados
+        return {
+            lat: lat2 * 180 / Math.PI,
+            lon: lon2 * 180 / Math.PI
+        };
+    }
+
+    /**
+     * 🧭 DIRECCIONES: Convertir azimuth a cardinal
+     */
+    private azimuthToCardinal(azimuth: number): string {
+        const directions = [
+            'North', 'Northeast', 'East', 'Southeast',
+            'South', 'Southwest', 'West', 'Northwest'
+        ];
+
+        const normalized = ((azimuth % 360) + 360) % 360; // Normalizar 0-360
+        const index = Math.round(normalized / 45) % 8;
+
+        return directions[index];
+    }
+
+    /**
+     * 🏔️ ELEVACIÓN: Convertir grados técnicos a descripción humana
+     */
+    /*private getElevationDescription(elevation: number): string {
+      if (elevation >= 70) {
+        return 'Almost directly overhead - look straight up';
+      } else if (elevation >= 50) {
+        return 'High in the sky - look up like seeing an airplane';
+      } else if (elevation >= 30) {
+        return 'Medium height - look up at 45° angle';
+      } else if (elevation >= 15) {
+        return 'Low in the sky - look toward the horizon';
+      } else {
+        return 'Very low - just above the horizon';
+      }
+    }*/
+
+    private getElevationDescription(elevation: number): string {
+        if (elevation >= 70) {
+            return 'Almost overhead';                    // Usuario mira directo arriba
+        } else if (elevation >= 45) {
+            return 'High in the sky';                    // Usuario mira arriba 
+        } else if (elevation >= 25) {
+            return 'Medium height';                      // Usuario mira arriba pero menos
+        } else if (elevation >= 15) {
+            return 'Low in the sky';                     // Usuario mira hacia arriba poco
+        } else {
+            return 'Close to horizon';                   // Usuario mira casi recto
+        }
+    }
+
+    /**
+     * 🎯 HELPER: Generar nombres direccionales simples
+     */
+    generateDirectionalNames(startAzimuth: number, endAzimuth: number): { from: string; to: string } {
+        return {
+            from: this.azimuthToCardinal(startAzimuth),
+            to: this.azimuthToCardinal(endAzimuth)
+        };
+    }
+}


### PR DESCRIPTION
### Summary
Make the app truly **worldwide** and **mobile-first**:
- Map **centered on the user** with mobile-friendly zoom (~15 on phones, ~13 desktop).
- **Cardinal directions only** in the UI (e.g., Northwest → Southeast): no city landmarks, no POI APIs.
- **LocalReferenceService** (new): math-only generator for universal references (cardinal labels + optional near-user start/end coords). In this PR we **use it for directions**; drawing of local markers is **not enabled by default**.
- Home cards with **human EN copy** (duration/brightness/elevation) and no duplicated info.
- Services hardened (fallbacks/bug fixes).

### What changed
- `src/app/services/local-reference.service.ts` **(new)**: 
  - `generateDirectionalNames()` for EN cardinal labels from azimuths.
  - `generateLocalReferences()` returns optional near-user appear/disappear coords (~1.5 km) + elevation description (not rendered by default).
- `src/app/features/map/map.component.ts`:
  - User-centered `flyTo` and zoom heuristic (15 mobile / 13 desktop).
  - Keep ISS trajectory/animation. No local reference markers drawn in this PR.
- `src/app/services/iss-passes.service.ts`:
  - Unify EN **cardinal directions** and **visibility/elevation** descriptors.
  - Day/night handling, remove city-specific logic.
- `src/app/features/home/home.component.html` / `.scss`:
  - Copy in EN, states **worldwide support**, remove landmark mentions and duplicated info.
- (If applicable) `iss-simple.service.ts` / `satellite-calculator.service.ts`:
  - More robust pipeline with fallbacks to avoid single-API failures.

### Why
- Universal UX in **any city** (Tokyo, NYC, Barcelona, …).
- Faster and more reliable: math + service fallbacks; **no external POI APIs**; good base for PWA.

### How to test
1. Run the app and allow geolocation.
2. Home → **See on map**:
   - Map opens **centered on your location**.
   - Zoom shows streets (~15 on mobile).
   - Trajectory/animation works; **no local reference markers** drawn.
3. Home:
   - EN human-friendly text (brightness/elevation/duration).
   - **Cardinal directions** (NW → SE).
   - **No city-specific strings**.

### Risks / Rollback
- Low risk: math/service-based only.
- Rollback: revert this PR.

### Checklist
- [x] Mobile viewport OK (center + zoom)
- [x] Cardinal-only directions (no landmarks; markers optional, not enabled)
- [x] `LocalReferenceService` added (math-only; PWA-friendly)
- [x] Human EN copy in Home without duplicates
- [x] Service fallbacks for robustness (ISS-now/TLE)
- [x] No secrets/tokens in repo
