### PR TITLE
feat(location): centralize validation in Home, add guards, fast IP retry

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 // src/app/app.routes.ts
 import { Routes } from '@angular/router';
+import { requireLocationGuard } from './guards/require-location.guard';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -10,16 +11,19 @@ export const routes: Routes = [
   },
   {
     path: 'map',
+    canActivate: [requireLocationGuard],
     loadComponent: () =>
       import('./features/map/map.component').then(m => m.MapComponent)
   },
   {
     path: 'iss',
+    canActivate: [requireLocationGuard],
     loadComponent: () =>
       import('./features/iss/iss.component').then(m => m.IssComponent)
   },
   {
     path: 'alerts',
+    canActivate: [requireLocationGuard],
     loadComponent: () =>
       import('./features/alerts/alerts/alerts.component').then(m => m.AlertsComponent)
   },
@@ -27,4 +31,3 @@ export const routes: Routes = [
 ];
 
 export class AppRoutingModule { }
-

--- a/src/app/features/home/home/home.component.html
+++ b/src/app/features/home/home/home.component.html
@@ -1,3 +1,18 @@
+@if (!hasValidLocation()) {
+<div class="location-overlay-home">
+  <div class="location-modal">
+    <i class="bi-geo "></i>
+    <h3>Location needed for ISS passes</h3>
+    <p>We need your location to calculate when ISS passes overhead.</p>
+    <button class="retry-btn" (click)="retryLocation()" [disabled]="isRetrying()">
+      <i class="bi bi-arrow-clockwise" [class.spinning]="isRetrying()"></i>
+      {{ isRetrying() ? 'Getting location...' : 'Try approximate location' }}
+    </button>
+    <small>We'll use internet-based location</small>
+  </div>
+</div>
+}
+
 <!-- INICIO - LA APP MAS SIMPLE DEL MUNDO -->
 <div class="simple-home">
 
@@ -30,21 +45,14 @@
       <div class="distance-icon">📍</div>
       <div class="distance-info">
         <h3>ISS right now</h3>
-        <div class="distance-big">{{ currentDistance() }} km</div>
-        <p>{{ distanceDescription() }}</p>
-        <!---   <div class="iss-direction-visual">
-        <span class="iss-satellite">🛰️</span>
-        
-        <div class="direction-info">
-          <div class="direction-line"></div>
-          <div class="direction-text">
-            {{ directionIcon() }} {{ issDirection().cardinal }}
-          </div>
-          <div class="movement-status">{{ issMovement() }}</div>
+        <div class="distance-big">
+          @if (currentDistance() !== null) {
+          {{ currentDistance() }} km
+          } @else {
+          ---
+          }
         </div>
-        
-        <span class="you-location">📍 You</span>
-      </div>-->
+        <p>{{ distanceDescription() }}</p>
         <button class="view-details-btn" (click)="showISSNow()">
           View details
         </button>
@@ -53,12 +61,12 @@
   </div>
 
   <!-- PRÓXIMOS PASES (clickeables) -->
+  @if (hasValidLocation()) {
   <div class="next-passes-simple">
     <h2>🗓️ When you'll see it</h2>
 
     <!-- 👇 Aviso sutil si lo que ves viene de caché -->
     @if (usingCache() && visiblePasses().length > 0) {
-
     <div class="status-note" aria-live="polite">
       Showing last known passes (cached)
     </div>
@@ -75,7 +83,6 @@
     @for (pass of visiblePasses(); track pass.id; let i = $index) {
     <div class="pass-card-simple" [class.night-pass]="isNightTime(pass.time)" [class.day-pass]="!isNightTime(pass.time)"
       (click)="goToMapWithPass(pass)" [class.next-pass]="i === 0">
-
       @if (i === 0) {
       <div class="next-badge">NEXT</div>
       }
@@ -110,6 +117,7 @@
     </div>
     }
   </div>
+  }
 
   <!-- BOTÓN GRANDE para ir al mapa -->
   <div class="map-cta">

--- a/src/app/features/home/home/home.component.scss
+++ b/src/app/features/home/home/home.component.scss
@@ -554,3 +554,115 @@
 .retry-btn {
   margin-top: 8px;
 }
+// ===== OVERLAY DE UBICACIÓN =====
+.location-overlay-home {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.location-modal {
+  background: white;
+  padding: 2rem;
+  border-radius: 16px;
+  text-align: center;
+  max-width: 320px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+
+  i {
+    font-size: 3rem;
+    color: #6c757d;
+    margin-bottom: 1rem;
+  }
+
+  h3 {
+    margin: 0 0 1rem;
+    color: #2D3E99;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0 0 1.5rem;
+    color: #495057;
+    line-height: 1.4;
+  }
+
+  .retry-btn {
+    background: linear-gradient(135deg, #2D3E99, #3B4FBA);
+    border: none;
+    border-radius: 12px;
+    padding: 0.75rem 1.5rem;
+    color: white;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin: 0 auto;
+
+    &:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(45, 62, 153, 0.3);
+    }
+
+    &:disabled {
+      opacity: 0.7;
+      cursor: not-allowed;
+      transform: none;
+    }
+
+    i {
+      font-size: 1rem;
+      color: white;
+      margin: 0;
+
+      &.spinning {
+        animation: spin 1s linear infinite;
+      }
+    }
+  }
+
+  small {
+    display: block;
+    margin-top: 1rem;
+    color: #6c757d;
+    font-size: 0.85rem;
+    line-height: 1.3;
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@media (max-width: 768px) {
+  .location-modal {
+    padding: 1.5rem;
+    max-width: 280px;
+    margin: 0 1rem;
+
+    i {
+      font-size: 2.5rem;
+    }
+
+    h3 {
+      font-size: 1.1rem;
+    }
+
+    p {
+      font-size: 0.9rem;
+    }
+  }
+}

--- a/src/app/features/map/map.component.ts
+++ b/src/app/features/map/map.component.ts
@@ -8,7 +8,6 @@ import type { Feature, LineString, GeoJsonProperties } from 'geojson';
 import { environment } from '../../../environments/environment';
 import { Router, ActivatedRoute } from '@angular/router';
 import { PassMap } from '../../interfaces/pass.interface';
-//import { N2YOPassesService } from '../../services/n2yo-passes.service'; // ← SOLO N2YO
 import { ISSPassesService } from '../../services/iss-passes.service';
 import { LocationSimpleService } from '../../services/location-simple.service';
 import { LocalReferenceService } from '../../services/local-reference.service';
@@ -23,8 +22,6 @@ import { LocalReferenceService } from '../../services/local-reference.service';
 })
 export class MapComponent implements OnInit {
 
-  // ===== SOLO N2YO =====
-  //private n2yoService = inject(N2YOPassesService);
   private passesService = inject(ISSPassesService);
   private locationService = inject(LocationSimpleService);
   private localReference = inject(LocalReferenceService);
@@ -46,6 +43,7 @@ export class MapComponent implements OnInit {
     console.log('❌ No location, using Barcelona fallback');
     return [0, 0]; // Fallback Barcelona
   });
+
 
   mapCenter = computed<[number, number]>(() => this.userLocation());
 
@@ -99,7 +97,7 @@ export class MapComponent implements OnInit {
     // 🚀 ASEGURAR UBICACIÓN REAL ANTES DE TODO
     try {
       console.log('📍 Verificando ubicación real para mapa...');
-      await this.locationService.getUserLocation();
+    //  await this.locationService.getUserLocation();
 
       const userLoc = this.locationService.location();
       console.log('🗺️ Ubicación para mapa:', userLoc);
@@ -116,7 +114,7 @@ export class MapComponent implements OnInit {
       const userLoc = this.locationService.location();
       if (userLoc) {
         console.log('🔍 Cargando pases INMEDIATAMENTE para mapa...');
-        await this.passesService.getRealPasses(userLoc.latitude, userLoc.longitude);
+       // await this.passesService.getRealPasses(userLoc.latitude, userLoc.longitude);
       }
 
       const availablePasses = this.allPasses();
@@ -161,103 +159,6 @@ export class MapComponent implements OnInit {
 
   initialZoom = signal<number>(12);
 
-  // ===== COORDENADAS DINÁMICAS =====
-  /* updateMapForPass(pass: PassMap) {
-     console.log(`🛰️ Actualizando mapa para pase: ${pass.id}`);
-     console.log(`📍 From: ${pass.from}, To: ${pass.to}`);
- 
-     // Calcular coordenadas dinámicamente
-     const startCoords = this.getLandmarkCoordinates(pass.from);
-     const endCoords = this.getLandmarkCoordinates(pass.to);
-     const userCoords = this.userLocation();
- 
-     console.log(`🎯 Coordenadas calculadas:`, { user: userCoords, start: startCoords, end: endCoords });
- 
-     this.issStartPoint.set(startCoords);
-     this.issEndPoint.set(endCoords);
- 
-     // Actualizar trajectory
-     this.trajectoryData.set({
-       type: 'Feature',
-       properties: {},
-       geometry: {
-         type: 'LineString',
-         coordinates: [startCoords, endCoords]
-       }
-     });
- 
-     if (this.map) {
-       this.fitMapToShowEverything(userCoords, startCoords, endCoords);
-     }
- 
-     if (this.movingISSMarker) {
-     const [lng, lat] = startCoords;
-     this.movingISSMarker.setLngLat([lng, lat]);
-     console.log('🛰️ Satélite reposicionado al nuevo punto de inicio');
-   }
-   
- 
-     console.log(`✅ Trayectoria actualizada para pase ${pass.id}`);
-   }*/
-
-  /* updateMapForPass(pass: PassMap) {
-    console.log(`🛰️ Actualizando mapa para pase: ${pass.id}`);
-    console.log(`📍 From: ${pass.from}, To: ${pass.to}`);
-
-    const userCoords = this.userLocation();
-    
-    // ✅ BUSCAR EL PASE COMPLETO con datos de azimuth
-    const allPasses = this.passesService.passes();
-    const fullPass = allPasses.find(p => p.id === pass.id);
-    
-    if (!fullPass || !fullPass.azimuth) {
-      console.error('❌ No se encontró pase completo con azimuth data');
-      return;
-    }
-
-    // ✅ USAR MATEMÁTICAS para calcular coordenadas
-    const localRef = this.localReference.generateLocalReferences(
-      userCoords[1], // lat
-      userCoords[0], // lon  
-      fullPass.azimuth.appear,
-      fullPass.azimuth.disappear,
-      50 // Elevación por defecto
-    );
-
-    const startCoords: [number, number] = localRef.startCoords;
-    const endCoords: [number, number] = localRef.endCoords;
-
-    console.log(`🎯 Coordenadas calculadas matemáticamente:`, { 
-      user: userCoords, 
-      start: startCoords, 
-      end: endCoords 
-    });
-
-    this.issStartPoint.set(startCoords);
-    this.issEndPoint.set(endCoords);
-
-    // Actualizar trajectory
-    this.trajectoryData.set({
-      type: 'Feature',
-      properties: {},
-      geometry: {
-        type: 'LineString',
-        coordinates: [startCoords, endCoords]
-      }
-    });
-
-    if (this.map) {
-      this.fitMapToShowEverythingPerfect(userCoords, startCoords, endCoords);
-    }
-
-    if (this.movingISSMarker) {
-      const [lng, lat] = startCoords;
-      this.movingISSMarker.setLngLat([lng, lat]);
-      console.log('🛰️ Satélite reposicionado al nuevo punto de inicio matemático');
-    }
-
-    console.log(`✅ Trayectoria actualizada matemáticamente para pase ${pass.id}`);
-  } */
 
   updateMapForPass(pass: PassMap) {
     console.log(`🛰️ Actualizando mapa para pase: ${pass.id}`);
@@ -266,7 +167,11 @@ export class MapComponent implements OnInit {
     const u = this.locationService.location();
     if (!u) {
       console.warn('[map] No hay user location aún; esperando...');
-      return; // tu setup/retry ya volverá a llamar
+      return;
+    }
+    if (u.latitude === 0 && u.longitude === 0) {
+      console.warn('[map] Ubicación inválida (0,0); abortando dibujo.');
+      return;
     }
     const userLonLat: [number, number] = [u.longitude, u.latitude];
 
@@ -307,42 +212,6 @@ export class MapComponent implements OnInit {
   }
 
 
-  /*private fitMapToShowEverything(
-    userCoords: [number, number], 
-    startCoords: [number, number], 
-    endCoords: [number, number]
-  ) {
-    if (!this.map) return;
-  
-    // 🎯 SIEMPRE centrar en el USUARIO como referencia
-    const userLat = userCoords[1];
-    const userLon = userCoords[0];
-    
-    // Calcular distancia máxima desde usuario a puntos ISS
-    const distanceToStart = this.calculateDistance(userCoords, startCoords);
-    const distanceToEnd = this.calculateDistance(userCoords, endCoords);
-    const maxDistance = Math.max(distanceToStart, distanceToEnd);
-    
-    const isMobile = window.innerWidth <= 768;
-    
-    // 🎯 Zoom inteligente basado en distancia desde usuario
-    let zoom = 12;
-    if (maxDistance < 3) zoom = isMobile ? 14 : 13;        // Muy cerca
-    else if (maxDistance < 8) zoom = isMobile ? 13 : 12;   // Cerca  
-    else if (maxDistance < 15) zoom = isMobile ? 12 : 11;  // Normal
-    else zoom = isMobile ? 11 : 10;                        // Lejos
-    
-    // 🎯 CENTRAR EN USUARIO, no en bounds automáticos
-    this.map.flyTo({
-      center: userCoords,  // Usuario SIEMPRE en el centro
-      zoom,
-      duration: 800,       // Suave y rápido
-      essential: true      // No cancelable
-    });
-    
-    console.log(`🎯 Zoom ${zoom} centrado en USUARIO (distancia max: ${maxDistance.toFixed(1)}km)`);
-  }*/
-
   private fitMapToShowEverythingPerfect(
     userCoords: [number, number],
     startCoords: [number, number],
@@ -366,82 +235,6 @@ export class MapComponent implements OnInit {
 
     console.log(`🎯 Mapa centrado en usuario con zoom ${perfectZoom}`);
   }
-
-  // 🔧 MÉTODO AUXILIAR: Calcular distancia
-  /*private calculateDistance(point1: [number, number], point2: [number, number]): number {
-    const [lon1, lat1] = point1;
-    const [lon2, lat2] = point2;
-    
-    const R = 6371; // Radio de la Tierra en km
-    const dLat = (lat2 - lat1) * Math.PI / 180;
-    const dLon = (lon2 - lon1) * Math.PI / 180;
-    
-    const a = Math.sin(dLat/2) * Math.sin(dLat/2) +
-              Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * 
-              Math.sin(dLon/2) * Math.sin(dLon/2);
-              
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
-    return R * c;
-  }
-    /**
-     * 📍 Centrar mapa en usuario (botón adicional)
-     */
-  /* centerOnUser() {
-     if (!this.map) return;
-     
-     const userCoords = this.userLocation();
-     this.map.flyTo({
-       center: userCoords,
-       zoom: 15,
-       duration: 1500
-     });
-     
-     console.log('📍 Mapa centrado en usuario');
-   }*/
-
-  /**
-   * 🛰️ Centrar en el pase (botón adicional) 
-   */
-  /*centerOnPass() {
-    if (!this.map) return;
-    
-    const startCoords = this.issStartPoint();
-    const endCoords = this.issEndPoint();
-    
-    // Centro entre start y end
-    const centerLng = (startCoords[0] + endCoords[0]) / 2;
-    const centerLat = (startCoords[1] + endCoords[1]) / 2;
-    
-    this.map.flyTo({
-      center: [centerLng, centerLat],
-      zoom: 13,
-      duration: 1500
-    });
-    
-    console.log('🛰️ Mapa centrado en pase ISS');
-  }*/
-
-  /**
-   * 🏙️ Coordenadas reales de Barcelona
-   */
-  /* private getLandmarkCoordinates(landmark: string): [number, number] {
-     const coordinates: Record<string, [number, number]> = {
-       'Tibidabo': [2.120, 41.422],
-       'Collserola': [2.100, 41.420],
-       'Sagrada Família': [2.174, 41.404],
-       'Sant Adrià': [2.220, 41.430],
-       'Barceloneta': [2.189, 41.379],
-       'Montjuïc': [2.166, 41.363],
-       'Hospital Clínic': [2.153, 41.390],
-       'Zona Universitària': [2.114, 41.387],
-       'Park Güell': [2.153, 41.414],
-       'Port Vell': [2.182, 41.377],
-       'Diagonal': [2.158, 41.397],
-       'Eixample': [2.165, 41.395]
-     };
- 
-     return coordinates[landmark] || [2.169, 41.387]; // Centro Barcelona
-   }*/
 
   ngOnDestroy(): void {
     // Cleanup si es necesario

--- a/src/app/guards/require-location.guard.ts
+++ b/src/app/guards/require-location.guard.ts
@@ -1,0 +1,20 @@
+// src/app/guards/require-location.guard.ts
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { LocationSimpleService } from '../services/location-simple.service';
+
+export const requireLocationGuard: CanActivateFn = () => {
+  const locationService = inject(LocationSimpleService);
+  const router = inject(Router);
+  
+  const location = locationService.location();
+  const hasValidLocation = location && location.latitude !== 0 && location.longitude !== 0;
+  
+  if (hasValidLocation) {
+    console.log('✅ Guard: ubicación válida, permitiendo acceso');
+    return true;
+  }
+  
+  console.log('❌ Guard: sin ubicación válida, redirigiendo a home');
+  return router.parseUrl('/');
+};

--- a/src/app/services/iss-passes.service.ts
+++ b/src/app/services/iss-passes.service.ts
@@ -25,14 +25,19 @@ export class ISSPassesService {
    * 🛰️ Obtener pases reales usando satellite.js - CON UI INTELIGENTE
    */
   async getRealPasses(latitude: number, longitude: number): Promise<PassHome[]> {
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude) ||
+      (latitude === 0 && longitude === 0)) {
+      console.warn('[passes] Invalid location; keeping current cache');
+      return this.realPasses();
+    }
     try {
-      console.log('🛰️ Calculando pases REALES con satellite.js para:', { latitude, longitude });
+      console.log('🛰️ Calculating REAL passes with satellite.js for:', { latitude, longitude });
 
       // Evitar cálculos duplicados
       if (this.lastFetchLocation &&
         Math.abs(this.lastFetchLocation.lat - latitude) < 0.01 &&
         Math.abs(this.lastFetchLocation.lon - longitude) < 0.01) {
-        console.log('📋 Usando pases cacheados');
+        console.log('📋 Using cached passes');
         return this.realPasses();
       }
 
@@ -44,10 +49,10 @@ export class ISSPassesService {
         5  // mínimo 5° elevación
       );
 
-      console.log('🔢 Cálculos satellite.js REALES:', calculations.length);
+      console.log('🔢 REAL satellite.js calculations:', calculations.length);
 
       if (calculations.length === 0) {
-        console.log('⚠️ No se encontraron pases, usando fallback');
+        console.log('⚠️ No passes found, using fallback');
         const fallbackPasses = this.generateRealisticFallback();
         this.realPasses.set(fallbackPasses);
         return fallbackPasses;
@@ -62,8 +67,8 @@ export class ISSPassesService {
       const nightPasses = allPasses.filter(pass => this.isNightPass(pass.time));
       const dayPasses = allPasses.filter(pass => !this.isNightPass(pass.time));
 
-      console.log(`🌙 Pases nocturnos REALES: ${nightPasses.length}`);
-      console.log(`☀️ Pases diurnos REALES: ${dayPasses.length}`);
+      console.log(`🌙 REAL night passes: ${nightPasses.length}`);
+      console.log(`☀️ REAL day passes:  ${dayPasses.length}`);
 
       let finalPasses: PassHome[];
 
@@ -74,7 +79,7 @@ export class ISSPassesService {
           viewable: true,
           reason: 'Perfect night viewing'
         }));
-        console.log('🌙 Usando 3 pases nocturnos REALES');
+        console.log('🌙 Using 3 REAL night passes');
 
       } else if (nightPasses.length > 0) {
         // ⚠️ Pocos nocturnos - combinar con mejores diurnos
@@ -94,7 +99,7 @@ export class ISSPassesService {
             reason: 'Daylight pass - not visible'
           }))
         ];
-        console.log(`🌓 Combinando ${nightPasses.length} nocturnos + ${brightDayPasses.length} diurnos`);
+        console.log(`🌓 Combining ${nightPasses.length} night + ${brightDayPasses.length} day`);
 
       } else {
         // ❌ No hay nocturnos esta semana - mostrar los mejores diurnos + info
@@ -103,7 +108,7 @@ export class ISSPassesService {
           viewable: false,
           reason: 'Daylight pass - not visible'
         }));
-        console.log('☀️ Solo pases diurnos esta semana');
+        console.log('☀️ Only day passes this week');
       }
       // 🎯 ORDENAR CRONOLÓGICAMENTE
       finalPasses = finalPasses.sort((a, b) =>
@@ -119,11 +124,11 @@ export class ISSPassesService {
       this.realPasses.set(finalPasses);
       this.lastFetchLocation = { lat: latitude, lon: longitude };
 
-      console.log('✅ Pases REALES calculados con satellite.js:', finalPasses.length);
+      console.log('✅ REAL passes calculated with satellite.js:', finalPasses.length);
       return finalPasses;
 
     } catch (error) {
-      console.error('❌ Error calculando pases REALES:', error);
+      console.error('❌ Error calculating REAL passes:', error);
 
       // Fallback solo si satellite.js falla completamente
       const fallbackPasses = this.generateRealisticFallback();

--- a/src/app/services/location-simple.service.ts
+++ b/src/app/services/location-simple.service.ts
@@ -190,4 +190,8 @@ export class LocationSimpleService {
     console.log('🔄 Forzando actualización de ubicación...');
     return this.getUserLocation();
   }
+  setLocation(location: UserLocationSimple): void {
+  this.currentLocation.set(location);
+  localStorage.setItem('last-location', JSON.stringify(location));
+}
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -43,3 +43,8 @@ bottom-nav {
   min-height: -webkit-fill-available;
   /* Fallback */
 }
+
+body.location-required .bottom-nav .nav-item:not([href*="/home"]) {
+  opacity: 0.4;
+  pointer-events: none;
+}


### PR DESCRIPTION
# Summary

Centralize user-location resolution in Home, protect Map/ISS/Alerts with a route guard, and make retry fast via direct IP geolocation (no GPS re-prompt). While location is unavailable, bottom tabs are visually disabled. Also preserve cached passes when coords are invalid.

# Problem / Why

- When users deny GPS, the app was showing the map around (0,0) or entering inconsistent states.  
- Sometimes Map opened before location or passes finished loading, so users saw an empty/incorrect view.  
- Retrying location felt slow because it waited for GPS timeout (~15s) before falling back to IP.  

# What Changed

## Home
- `hasValidLocation` is the single source of truth (adds/removes a global `<body>` class).  
- `retryLocation()` now uses direct IP for a fast retry and loads passes on success.  
- `isRetrying` shows visual feedback on the retry button.  
- `visiblePasses` only shows passes when there is a valid location.  
- Location badge keeps `≈` when the source is IP (approximate).  

## Route Guard
- `require-location.guard.ts` blocks `/map`, `/iss`, and `/alerts` if lat/lon are invalid and redirects to `/`.  

## Global Styles
- When `<body>` has `location-required`, bottom tabs are visually disabled (opacity + `pointer-events: none`).  

## Map
- Removed local overlay and `hasValidLocation` (Home + guard handle access).  
- Kept defensive checks in `updateMapForPass` to ignore (0,0).  

## Passes Service (`iss-passes.service.ts`)
- Early guard for invalid coords; returns cached passes instead of `[]` during transient failures.  

## Location Service
- Added `setLocation()` to allow controlled updates/persistence.  

# User Impact

- If GPS is denied, users now see a clear overlay in Home instead of a broken map.  
- Retry is fast (~2–3s via IP) and doesn’t ask for permissions again.  
- Tabs stay disabled until location is resolved, so users never end up at (0,0).  
- Approximate locations are clearly marked (`≈ City`), so expectations are set.  

# Performance

- Retry is ~2–3s via IP (was ~15s waiting for GPS timeout + IP).  
- Removes cross-screen race conditions and redundant fetches.  

# Privacy & Permissions

- No new permission prompts are needed when retrying.  
- Users always know if the location comes from IP because the UI shows it explicitly.  

# Risks & Mitigations

- **Potential issue:** A user could get blocked from accessing routes like `/map` if the location state doesn’t update correctly.  
- **How we prevent it:** The route guard, the `<body>` class, and the Home overlay all rely on the same shared signal/state. This ensures everything stays in sync and avoids inconsistencies.  

# Test Plan

- Deny GPS → IP works: Home overlay → Try again → ~2–3s passes appear → tabs enabled → Map shows trajectory.  
- Deny GPS → IP fails: Overlay persists; tabs disabled; retry remains available.  
- Approximate location: Badge shows `≈ City`; passes load; Map OK.  
- Deep link protection: Direct to `/map` without valid location → redirected to `/`.  
- Open Map from Home card: With passes loaded, “View on map” renders the correct pass.  
- Force (0,0): Service returns cached passes; no recompute with invalid coords.  
