### PR TITLE
fix(map): resolve white gap on mobile and harden map resize behavior

### DIFF
--- a/src/app/features/map/map.component.scss
+++ b/src/app/features/map/map.component.scss
@@ -60,6 +60,7 @@
 .mobile-map-container {
   position: relative;
   flex: 1;
+  min-height: 0; 
 }
 
 .mobile-map {
@@ -692,4 +693,8 @@ div:has-text("🛰️") {
       order: 3;
     }
   }
+}
+
+.mapboxgl-canvas {
+  display: block; /* evita espacios por baseline inline */
 }


### PR DESCRIPTION
### What
- CSS: Add `min-height: 0` to `.mobile-map-container` to fix flexbox height calculation on mobile.
- CSS: Set `.mapboxgl-canvas { display: block; }` to avoid inline baseline spacing.
- TS: Implement `AfterViewInit` + window `resize`/`orientationchange` listeners with a 120 ms debounce.
- TS: Trigger an initial `map.resize()` right after `mapLoad` for correct initial dimensions.
- TS: Proper cleanup of listeners in `ngOnDestroy` to prevent memory leaks.

### Why
- Removes the persistent “white gap” under the map on mobile and hardens the layout against viewport changes and rotations.

### QA
- ✅ Manually tested on desktop Chrome (DevTools mobile emulation).
- ✅ Tested on Android (Chrome).
- ⭕ To validate on iOS Safari.
- No public API changes.

### Notes
- Should reduce the issue from “constant” to “edge-case only”.
